### PR TITLE
Fix incorrect device naming

### DIFF
--- a/init/init_haydn.cpp
+++ b/init/init_haydn.cpp
@@ -55,28 +55,27 @@ void property_override(const std::string& name, const std::string& value)
     }
 }
 
-void model_property_override(const std::string& device, const std::string& model)
+void model_property_override(const std::string& device, const std::string& name, const std::string& model)
 {
-    property_override("ro.product.device", device);
-    property_override("ro.product.odm.device", device);
-    property_override("ro.product.system.device", device);
-    property_override("ro.product.vendor.device", device);
     property_override("ro.build.product", device);
-    property_override("ro.product.name", device);
-    property_override("ro.product.odm.name", device);
+    property_override("ro.product.device", device);
+    property_override("ro.product.odm.device", device););
+    property_override("ro.product.vendor.device", device);
     property_override("ro.product.product.device", device);
-    property_override("ro.product.product.name", device);
-    property_override("ro.product.system.name", device);
     property_override("ro.product.system_ext.device", device);
-    property_override("ro.product.system_ext.name", device);
-    property_override("ro.product.vendor.name", device);
+    property_override("ro.product.system.device", device
+    property_override("ro.product.name", name);
+    property_override("ro.product.odm.name", name);
+    property_override("ro.product.vendor.name", name);
+    property_override("ro.product.product.name", name);
+    property_override("ro.product.system_ext.name", name);
+    property_override("ro.product.system.name", name);
     property_override("ro.product.model", model);
     property_override("ro.product.odm.model", model);
-    property_override("ro.product.system.model", model);
     property_override("ro.product.vendor.model", model);
     property_override("ro.product.product.model", model);
     property_override("ro.product.system_ext.model", model);
-
+    property_override("ro.product.system.model", model);
 }
 
 void vendor_load_properties() {
@@ -88,14 +87,14 @@ void vendor_load_properties() {
     bool isCN = GetProperty("ro.boot.hwc", "") == "CN";
     if (sku == "haydn") {
       if (isCN)
-        model_property_override("haydn", "Redmi K40 Pro");
+        model_property_override("haydn", "haydn", "Redmi K40 Pro");
       else
-        model_property_override("haydn", "Mi 11i");
+        model_property_override("haydn", "haydn", "Mi 11i");
     } else if (sku == "haydnpro") {
-      model_property_override("haydnpro", "Redmi K40 Pro+");
+      model_property_override("haydn", "haydnpro", "Redmi K40 Pro+");
     } else if (sku == "haydn_in") {
-      model_property_override("haydn_in", "Mi 11X Pro");
+      model_property_override("haydnin", "haydn_in", "Mi 11X Pro");
     } else {
-      model_property_override("unknow", "unknow name");
+      model_property_override("unknown", "unknown", "unknown name");
     }
 }

--- a/recovery/root/customzip/Magisk/MagiskAlphaVer
+++ b/recovery/root/customzip/Magisk/MagiskAlphaVer
@@ -1,1 +1,1 @@
-Magisk-4eb71830-alpha[25101]-220621
+Magisk-0b26882f-alpha[25101]-220701


### PR DESCRIPTION
ro.product.*.device values "haydnpro" and "haydn_in" don't exist and never existed, those are only applicable for ro.product.*.name.
There are only "haydn" and "haydnin" for ro.product.*.device.
This mistake prevents flashing ROMs that check for the ro.product.device.